### PR TITLE
Add release orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8.20.1
+  orb-tools: artsy/orb-tools@0.2.0
 
 workflows:
-  validate-and-publish:
+  publish-orbs:
     jobs:
-      - orb-tools/lint
+      - orb-tools/publish:
+          namespace: auto
+          context: auto-orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+  orb-tools: circleci/orb-tools@8.20.1
+
+workflows:
+  validate-and-publish:
+    jobs:
+      - orb-tools/lint

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ jobs:
       # ... your build steps here
       - auto/shipit
 ```
+
+## Configuration
+
+The `auto/release` orb can be configured using the following environment variables
+
+- `AUTO_VERSION`: Specifies which version of auto to install. It must be a valid tag which can be found on the [releases page](https://github.com/intuit/auto/releases). It defaults to the latest version.
+- `AUTO_PLATFORM`: Specifies which platform the auto executable will be downloaded for. The options are linux, macos, win. The default is linux.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ The `auto/release` orb can be configured using the following environment variabl
 
 - `AUTO_VERSION`: Specifies which version of auto to install. It must be a valid tag which can be found on the [releases page](https://github.com/intuit/auto/releases). It defaults to the latest version.
 - `AUTO_PLATFORM`: Specifies which platform the auto executable will be downloaded for. The options are linux, macos, win. The default is linux.
+
+Auto itself **requires** `GH_TOKEN` be provided to be able to update labels and make comments on GitHub.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto Orbs
+
+A [circleci orb](https://circleci.com/docs/2.0/orb-intro/) that makes it easy to integrate [auto](https://github.com/intuit/auto) into your project.
+
+## Usage
+
+```yaml
+version: 2.1
+
+orbs:
+  auto: auto/release@1.0.0
+
+jobs:
+  build:
+    steps:
+      # ... your build steps here
+      - auto/shipit
+```

--- a/orbs/release.yml
+++ b/orbs/release.yml
@@ -1,0 +1,37 @@
+# To override the version of auto, set an AUTO_VERSION env var
+version: 2.1
+
+commands:
+  get-version:
+    description: Ensures the AUTO_VERSION env var is set for the current job
+    steps:
+      - run:
+          command: |
+            if [ -z "$AUTO_VERSION" ]; then
+              AUTO_VERSION=$(curl -s https://api.github.com/repos/intuit/auto/releases/latest | jq -r .tag_name)
+            fi
+            echo "export AUTO_VERSION=$AUTO_VERSION" >> $BASH_ENV
+
+  download-executable:
+    parameters:
+      platform:
+        type: enum
+        default: linux
+        description: Which platform binary to download
+        enum: ["linux", "macos", "win"]
+    steps:
+      - get-version
+      - run:
+          description: Download and unzipping auto binary
+          command: |
+            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-<< parameters.platform >>.gz" -o auto.gz
+            gzip -d auto.gz
+
+  shipit:
+    parameters:
+      arguments:
+        type: string
+        description: Optional argument string to be passed to auto shipit
+    steps:
+      - download-executable
+      - run: ./auto shipit << parameters.arguments >> $AUTO_SHIPIT_ARGS

--- a/orbs/release.yml
+++ b/orbs/release.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 commands:
-  get-version:
+  get-envs:
     description: Ensures the AUTO_VERSION env var is set for the current job
     steps:
       - run:
@@ -10,21 +10,20 @@ commands:
             if [ -z "$AUTO_VERSION" ]; then
               AUTO_VERSION=$(curl -s https://api.github.com/repos/intuit/auto/releases/latest | jq -r .tag_name)
             fi
+            # Must be linux, macos, or win
+            if [ -z "$AUTO_PLATFORM" ]; then
+              AUTO_PLATFORM=linux
+            fi
             echo "export AUTO_VERSION=$AUTO_VERSION" >> $BASH_ENV
+            echo "export AUTO_PLATFORM=$AUTO_PLATFORM" >> $BASH_ENV
 
   download-executable:
-    parameters:
-      platform:
-        type: enum
-        default: linux
-        description: Which platform binary to download
-        enum: ["linux", "macos", "win"]
     steps:
-      - get-version
+      - get-envs
       - run:
           description: Download and unzipping auto binary
           command: |
-            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-<< parameters.platform >>.gz" -o auto.gz
+            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o auto.gz
             gzip -d auto.gz
 
   shipit:

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,3 @@
+GET_VERSION() {
+  echo $(curl -s https://api.github.com/repos/intuit/auto/releases/latest | jq -r .tag_name)
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,3 +1,0 @@
-GET_VERSION() {
-  echo $(curl -s https://api.github.com/repos/intuit/auto/releases/latest | jq -r .tag_name)
-}

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -1,3 +1,5 @@
+# Orb Version 0.0.1
+
 # To override the version of auto, set an AUTO_VERSION env var
 version: 2.1
 
@@ -31,6 +33,7 @@ commands:
       arguments:
         type: string
         description: Optional argument string to be passed to auto shipit
+        default: ""
     steps:
       - download-executable
       - run: ./auto shipit << parameters.arguments >> $AUTO_SHIPIT_ARGS


### PR DESCRIPTION
Adds the release orb which will be the default orb for using auto. This downloads the executable from GitHub releases as a mechanism for running auto (as opposed to using something like npx). 

This is needed by Artsy being as npx is still kind of broken. 

cc @hipstersmoothie 

## Usage

An example of what the circleci config of a project using this orb would look like

```
orbs:
  auto: auto/release@1.0.0

jobs:
  build:
    steps: 
      - run: ./build.sh
      - auto/shipit
```

## TODO

- [x] Finish setting up circleci config for this project
- [x] Make platform configurable by environment variable
- [x] Write usage documentation in orb and README
- [x] Document environment variables