### PR TITLE
Updates orb-tools with docker path fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: artsy/orb-tools@0.2.1
+  orb-tools: artsy/orb-tools@dev:0.2.2.169c268c8ea5b508c8df0877b1b46a0e
 
 workflows:
   publish-orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: artsy/orb-tools@dev:0.2.2.169c268c8ea5b508c8df0877b1b46a0e
+  orb-tools: artsy/orb-tools@0.2.2
 
 workflows:
   publish-orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: artsy/orb-tools@0.2.0
+  orb-tools: artsy/orb-tools@0.2.1
 
 workflows:
   publish-orbs:


### PR DESCRIPTION
Okay, so master was failing to publish because it couldn't find the scripts from Artsy's orb tools. Turns out I was dumping them in the working directory (home?) and the working directory was being changed by Circle. 

I moved the scripts to a root directory and added a sym-link later in the job... so this _should_ work. 