### PR TITLE
Move binary, add test command

### DIFF
--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.0.2
+# Orb Version 0.0.3
 
 # To override the version of auto, set an AUTO_VERSION env var
 version: 2.1
@@ -26,9 +26,16 @@ commands:
       - run:
           name: Download Auto binary
           command: |
-            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o auto.gz
-            gzip -d auto.gz
-            chmod +x ./auto
+            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o /usr/local/bin/auto.gz
+            gzip -d /usr/local/bin/auto.gz
+            chmod +x /usr/local/bin/auto
+            
+  test-binary:
+    steps:
+      - download-executable
+      - run:
+          name: Verify Auto binary
+          command: command -v auto
 
   shipit:
     parameters:

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -29,13 +29,6 @@ commands:
             curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o /usr/local/bin/auto.gz
             gzip -d /usr/local/bin/auto.gz
             chmod +x /usr/local/bin/auto
-            
-  test-binary:
-    steps:
-      - download-executable
-      - run:
-          name: Verify Auto binary
-          command: command -v auto
 
   shipit:
     parameters:


### PR DESCRIPTION
This PR moves the `auto` executable to `/usr/local/bin` so that it can be accessed more globally. 

It also adds a test command that can be used to verify the download.