### PR TITLE
Fix curl permission issues

### DIFF
--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -26,9 +26,10 @@ commands:
       - run:
           name: Download Auto binary
           command: |
-            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o /usr/local/bin/auto.gz
-            gzip -d /usr/local/bin/auto.gz
-            chmod +x /usr/local/bin/auto
+            curl -L "https://github.com/intuit/auto/releases/download/$AUTO_VERSION/auto-$AUTO_PLATFORM.gz" -o /tmp/auto.gz
+            gzip -d /tmp/auto.gz
+            chmod +x /tmp/auto
+            sudo mv /tmp/auto /usr/local/bin/auto
 
   shipit:
     parameters:


### PR DESCRIPTION
Ran into more issues... Curl didn't have permissions to write to `/usr/local/bin`. I thought I'd sufficiently tested this previously, but obviously I was mistaken. That's how it goes I suppose. 

I'm going to build an automated testing mechanism for this in the near future, but for now I SSH'd into the circleci box and tried this manually. 

