### PR TITLE
Add canary command to release orb

### DIFF
--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -53,4 +53,4 @@ commands:
       - download-executable
       - run:
           name: auto canary
-          command: auto canary << parameters.arguments >> $AUTO_CANARY_ARGS
+          command: [[ -z "${GH_TOKEN}" ]] && echo "GH_TOKEN environment variable not set, skipping canary deploy" || auto canary << parameters.arguments >> $AUTO_CANARY_ARGS

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -53,10 +53,10 @@ commands:
       - run:
           name: Check for GH_TOKEN
           command: |
-          if [[ -z "${GH_TOKEN}" ]]; then 
-            echo "GH_TOKEN environment variable not set, skipping canary deploy" 
-            circleci-agent step halt
-          fi
+            if [[ -z "${GH_TOKEN}" ]]; then 
+              echo "GH_TOKEN environment variable not set, skipping canary deploy" 
+              circleci-agent step halt
+            fi
       - download-executable
       - run:
           name: auto canary

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.0.5
+# Orb Version 0.0.6
 
 # To override the version of auto, set an AUTO_VERSION env var
 version: 2.1
@@ -42,3 +42,15 @@ commands:
       - run:
           name: auto shipit
           command: auto shipit << parameters.arguments >> $AUTO_SHIPIT_ARGS
+
+  canary:
+    parameters:
+      arguments:
+        type: string
+        description: Optional argument string to be passed to auto canary
+        default: ""
+    steps:
+      - download-executable
+      - run:
+          name: auto canary
+          command: auto canary << parameters.arguments >> $AUTO_CANARY_ARGS

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -50,7 +50,14 @@ commands:
         description: Optional argument string to be passed to auto canary
         default: ""
     steps:
+      - run:
+          name: Check for GH_TOKEN
+          command: |
+          if [[ -z "${GH_TOKEN}" ]]; then 
+            echo "GH_TOKEN environment variable not set, skipping canary deploy" 
+            circleci-agent step halt
+          fi
       - download-executable
       - run:
           name: auto canary
-          command: [[ -z "${GH_TOKEN}" ]] && echo "GH_TOKEN environment variable not set, skipping canary deploy" || auto canary << parameters.arguments >> $AUTO_CANARY_ARGS
+          command: auto canary << parameters.arguments >> $AUTO_CANARY_ARGS

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.0.6
+# Orb Version 0.1.0
 
 # To override the version of auto, set an AUTO_VERSION env var
 version: 2.1


### PR DESCRIPTION
Adds a new canary command that can be used in circle jobs to create a canary deployment. 

Given the challenges around env vars and forks, it will pass without deploying if the appropriate env var isn't present.  

cc @hipstersmoothie 